### PR TITLE
To v120

### DIFF
--- a/.github/workflows/deploy-to-render.yml
+++ b/.github/workflows/deploy-to-render.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           push: true
           #tags: ${{ secrets.DOCKERHUB_TAG }} # Example: username/project:latest
-          tags: vuqu/nfcapstone:v1.1.9s # Example: username/project:latest # postfix "s" in vuqu/nfcapstone:v1.X.Xs stands for static and is for VPS deployment
+          tags: vuqu/nfcapstone:v1.2.0 # Example: username/project:latest # postfix "s" in vuqu/nfcapstone:v1.X.Xs stands for static and is for VPS deployment
           context: .  # It tells the Docker builder where to find the source code and the Dockerfile it needs to build the image. The single dot (.) is a shorthand reference to the root of my repository, where the workflow is currently running. This means Docker will use the entire cloned repository as the "build context" and look for the Dockerfile within that directory.
 
   deploy:

--- a/backend/src/main/java/org/pupille/backend/mysql/screening/ScreeningController.java
+++ b/backend/src/main/java/org/pupille/backend/mysql/screening/ScreeningController.java
@@ -20,7 +20,7 @@ public class ScreeningController {
         return screeningService.getAllFutureTermineWithFilms();
     }
 
-//            // this can be used when Reihe information in addition to  required in Gallery
+//            // this can be used when Reihe information is required in Gallery
 //            @GetMapping("/new")
 //            public ReihenAndFilmTermineForGallery getReihenAndTermineForGallery() {
 //                return screeningService.getReihenAndTermineForGallery();

--- a/frontend/src/components/overview/OverviewClicks.tsx
+++ b/frontend/src/components/overview/OverviewClicks.tsx
@@ -88,20 +88,20 @@ const OverviewClicks: React.FC = () => {
 
                             <p>Generell: Keine Zählung bei Klicks zeitlich nach der Vorführung</p>
 
-                            <div className={styles.zaehlartenbox}>
-                                <h3 className={styles.title3}>session:</h3>
-                                <p>Die Zählung findet innerhalb 1 Browsersession (geöffnetes Browserfenster oder -tab) statt: Beim mehrmaligen Öffnen einer Detailseite oder mehrmaligen Klicken auf die Kalenderfunktion erfolgt keine Mehrfachzählung, sondern nur der 1. Klick wird 1-fach gezählt. Ein neues Browserfenster bzw. -tab zählt als neue Session. D. h. hier erfolgt die Zählung wieder beim 1. Klick.</p>
-                            </div>
+                            {/*<div className={styles.zaehlartenbox}>*/}
+                            {/*    <h3 className={styles.title3}>session:</h3>*/}
+                            {/*    <p>Die Zählung findet innerhalb 1 Browsersession (geöffnetes Browserfenster oder -tab) statt: Beim mehrmaligen Öffnen einer Detailseite oder mehrmaligen Klicken auf die Kalenderfunktion erfolgt keine Mehrfachzählung, sondern nur der 1. Klick wird 1-fach gezählt. Ein neues Browserfenster bzw. -tab zählt als neue Session. D. h. hier erfolgt die Zählung wieder beim 1. Klick.</p>*/}
+                            {/*</div>*/}
 
-                            <div className={styles.zaehlartenbox}>
-                                <h3 className={styles.title3}>user:</h3>
-                                <p className="mb-0">Diese Zahl ist ein Proxy für die Zahl der interessierten Personen. Die Zählung erfolgt pro User pro erstmaligem Klick in ein und desselben Browser. Ausnahmen davon:</p>
-                                <ul>
-                                    <li>User löscht manuell den lokalen Speicher oder den Browser-Cache.</li>
-                                    <li>User verwendet den privaten bzw. Inkognito-Modus; Daten des lokalen Speichers werden normalerweise nach Schließen des Modus gelöscht.</li>
-                                    <li>Einige Browser, wie Safari, löschen lokal gespeicherte Daten proaktiv, wenn eine Website für eine bestimmte Zeit (z.B. 7 Tage) nicht genutzt oder keine Benutzerinteraktion mehr erfolgt ist.</li>
-                                </ul>
-                            </div>
+                            {/*<div className={styles.zaehlartenbox}>*/}
+                            {/*    <h3 className={styles.title3}>user:</h3>*/}
+                            {/*    <p className="mb-0">Diese Zahl ist ein Proxy für die Zahl der interessierten Personen. Die Zählung erfolgt pro User pro erstmaligem Klick in ein und desselben Browser. Ausnahmen davon:</p>*/}
+                            {/*    <ul>*/}
+                            {/*        <li>User löscht manuell den lokalen Speicher oder den Browser-Cache.</li>*/}
+                            {/*        <li>User verwendet den privaten bzw. Inkognito-Modus; Daten des lokalen Speichers werden normalerweise nach Schließen des Modus gelöscht.</li>*/}
+                            {/*        <li>Einige Browser, wie Safari, löschen lokal gespeicherte Daten proaktiv, wenn eine Website für eine bestimmte Zeit (z.B. 7 Tage) nicht genutzt oder keine Benutzerinteraktion mehr erfolgt ist.</li>*/}
+                            {/*    </ul>*/}
+                            {/*</div>*/}
 
                             <h2 className={styles.title2}>Tage online</h2>
                             <p>Zeigt an wie lange das Screening in der Gallery (main page) auf der Webseite beworben wurde (Zählung der Tage nur bis Vorführungstag).</p>

--- a/frontend/src/components/overview/OverviewSemester2.tsx
+++ b/frontend/src/components/overview/OverviewSemester2.tsx
@@ -69,10 +69,10 @@ export default function OverviewSemester2() {
                 <div className="overview-container">
                     {semesterTermine
                         .filter(termin => {
-                            // -- skip Termin, when there's no corresponding Hauptfilm
-                            if (!termin.mainfilms || termin.mainfilms.length === 0) { // 1st condition checks if termin.mainfilms existent or field mainfilms not missing, while 2nd condition covers the case mainfilms: []
-                                return false;
-                            }
+                            // // -- skip Termin, when there's no corresponding Hauptfilm
+                            // if (!termin.mainfilms || termin.mainfilms.length === 0) { // 1st condition checks if termin.mainfilms existent or field mainfilms not missing, while 2nd condition covers the case mainfilms: []
+                            //     return false;
+                            // }
 
                             // -- filter for selected Filmreihe
                             // if (!selectedOption || !selectedOption.value) return true; // concise line below achieves the same

--- a/frontend/src/components/preview/PreviewFormWithinSlides.tsx
+++ b/frontend/src/components/preview/PreviewFormWithinSlides.tsx
@@ -4,7 +4,6 @@ import {Badge, Col, Container, Form, Row} from "react-bootstrap";
 import Button from "react-bootstrap/Button";
 import {formatDateInTerminSelectOption} from "../../utils/formatDateInTerminSelectOption.ts";
 import BackToTopButton from "../structural_components/BackToTopButton.tsx";
-import {renderHtmlText} from "../../utils/renderHtmlText.tsx";
 import Header2 from "../structural_components/Header2.tsx";
 
 interface Props {
@@ -100,6 +99,7 @@ const PreviewFormWithinSlides: React.FC<Props> = ({
                                     multiple
                                     name="selectScreenings"
                                     htmlSize={semesterTermine.length + 2}
+                                    // htmlSize={semesterTermine.filter((termin) => (termin.veroeffentlichen ?? 0) > 0).length + 2}
                                     value={selectValue}
                                     onChange={handleScreeningSelectionChange}
                                 >
@@ -109,17 +109,22 @@ const PreviewFormWithinSlides: React.FC<Props> = ({
                                     <option key="all_except_first" value="all_except_first">
                                         Alle Vorführungstermine ohne den nächsten
                                     </option>
-                                    {semesterTermine.map((termin) => (
-                                        <option key={termin.tnr} value={termin.tnr}>
-                                            {/*using renderHtmlText here causes a span inside an option → hydration errors*/}
-                                            {/*{formatDateInTerminSelectOption( termin.vorstellungsbeginn )} | {renderHtmlText( termin.titel || termin.mainfilms[0].titel )}*/}
-                                            {formatDateInTerminSelectOption( termin.vorstellungsbeginn )} {termin.isCanceled ? "🔴 " : "🟢 "} {termin.titel || termin.mainfilms[0].titel}
-                                        </option>
+                                    {semesterTermine
+                                        // .filter((termin) => (termin.veroeffentlichen ?? 0) > 0)
+                                        .map((termin) => (
+                                            <option key={termin.tnr} value={termin.tnr}>
+                                                {/*using renderHtmlText here causes a span inside an option → hydration errors*/}
+                                                {/*{formatDateInTerminSelectOption( termin.vorstellungsbeginn )} | {renderHtmlText( termin.titel || termin.mainfilms[0].titel )}*/}
+
+                                                {/*{formatDateInTerminSelectOption( termin.vorstellungsbeginn )} {termin.isCanceled ? "🔴 " : "🟢 "} {termin.titel || termin.mainfilms[0].titel}*/}
+                                                {formatDateInTerminSelectOption( termin.vorstellungsbeginn )} {termin.veroeffentlichen ? "🔓" : "🔒"}{termin.isCanceled ? "🔴" : "🟢"} {termin.titel || (termin.mainfilms?.[0]?.titel ?? "[no termin.title and no film(s) associated yet]")}
+                                            </option>
                                     ))}
                                 </Form.Select>
                                 <Form.Text className="text-muted">
                                     <ul className="tight-list">
                                         <li>STRG (Windows) oder CMD (Mac) gedrückt halten, um mehrere, nicht zusammenhängende Vorführungstermine auszuwählen.</li>
+                                        <li>🔓: Termin ist bereits auf Webseite sichtbar; 🔒: sonst </li>
                                         <li>🔴: Termin ist als "abgesagt" markiert; 🟢: sonst </li>
                                     </ul>
                                 </Form.Text>

--- a/frontend/src/utils/config.ts
+++ b/frontend/src/utils/config.ts
@@ -2,8 +2,8 @@ export const avgDurationTrailer = 12;
 
 // ---------------------------------------------------
 
-// const relativePathForVPSDeployment = ""; // use this to create docker image FOR render and localhost
-const relativePathForVPSDeployment = "/static-files/" // use this to create docker image FOR VPS docker deployment
+const relativePathForVPSDeployment = ""; // use this to create docker image FOR render and localhost
+// const relativePathForVPSDeployment = "/static-files/" // use this to create docker image FOR VPS docker deployment
 
 const absolutePathForRenderAndLocalhost = "https://www.pupille.org/static-files/"
 


### PR DESCRIPTION
- Fix the case of termin.mainfilms being an empty list by safe/defensive property access with fallback (i.e. null-safe fallback) + preparing code for filterung only termine with veroeffentlichen > 0
- Fix to also show termine without associating film(s) (by deactivating code for filtering) in OverviewSemester2.tsx
- Comment out explanations on user and session counting